### PR TITLE
Optimize get_color

### DIFF
--- a/src/vacuum_map_parser_base/config/color.py
+++ b/src/vacuum_map_parser_base/config/color.py
@@ -117,25 +117,35 @@ class ColorsPalette:
             self._overriden_room_colors = {}
         else:
             self._overriden_room_colors = room_colors
+        self._cached_colors = {}
+        self._cached_room_colors = {}
 
     def get_color(self, color_name: SupportedColor) -> Color:
-        if color_name in self._overriden_colors:
-            return self._overriden_colors[color_name]
-        elif color_name in ColorsPalette.COLORS:
-                return ColorsPalette.COLORS[color_name]
-        elif SupportedColor.UNKNOWN in ColorsPalette.COLORS:
-            return ColorsPalette.COLORS[SupportedColor.UNKNOWN]
-        return (0,0,0)
+        if color_name not in self._cached_colors:
+            if color_name in self._overriden_colors:
+                val = self._overriden_colors[color_name]
+            elif color_name in ColorsPalette.COLORS:
+                val = ColorsPalette.COLORS[color_name]
+            elif SupportedColor.UNKNOWN in ColorsPalette.COLORS:
+                val = ColorsPalette.COLORS[SupportedColor.UNKNOWN]
+            else:
+                val = (0,0,0)
+            self._cached_colors[color_name] = val
+        return self._cached_colors[color_name]
 
     def get_room_color(self, room_id: str | int) -> Color:
         if isinstance(room_id, str):
             room_id = int(room_id)
-        if room_id > len(ColorsPalette.ROOM_COLORS):
-            room_id = (room_id - 1) % len(ColorsPalette.ROOM_COLORS) + 1
+        if room_id not in self._cached_room_colors:
+            if room_id > len(ColorsPalette.ROOM_COLORS):
+                room_id = (room_id - 1) % len(ColorsPalette.ROOM_COLORS) + 1
 
-        key = str(room_id)
-        if key in self._overriden_room_colors:
-            return self._overriden_room_colors[key]
-        if key in ColorsPalette.ROOM_COLORS:
-            return ColorsPalette.ROOM_COLORS[key]
-        return ColorsPalette.ROOM_COLORS.get(str(self._random.randint(1, 16)), (0, 0, 0))
+            key = str(room_id)
+            if key in self._overriden_room_colors:
+                val = self._overriden_room_colors[key]
+            elif key in ColorsPalette.ROOM_COLORS:
+                val = ColorsPalette.ROOM_COLORS[key]
+            else:
+                val = ColorsPalette.ROOM_COLORS.get(str(self._random.randint(1, 16)), (0, 0, 0))
+            self._cached_room_colors[room_id] = val
+        return self._cached_room_colors[room_id]

--- a/src/vacuum_map_parser_base/config/color.py
+++ b/src/vacuum_map_parser_base/config/color.py
@@ -119,10 +119,13 @@ class ColorsPalette:
             self._overriden_room_colors = room_colors
 
     def get_color(self, color_name: SupportedColor) -> Color:
-        return self._overriden_colors.get(
-            color_name,
-            ColorsPalette.COLORS.get(color_name, ColorsPalette.COLORS.get(SupportedColor.UNKNOWN, (0, 0, 0))),
-        )
+        if color_name in self._overriden_colors:
+            return self._overriden_colors[color_name]
+        elif color_name in ColorsPalette.COLORS:
+                return ColorsPalette.COLORS[color_name]
+        elif SupportedColor.UNKNOWN in ColorsPalette.COLORS:
+            return ColorsPalette.COLORS[SupportedColor.UNKNOWN]
+        return (0,0,0)
 
     def get_room_color(self, room_id: str | int) -> Color:
         if isinstance(room_id, str):
@@ -131,10 +134,8 @@ class ColorsPalette:
             room_id = (room_id - 1) % len(ColorsPalette.ROOM_COLORS) + 1
 
         key = str(room_id)
-        return self._overriden_room_colors.get(
-            key,
-            ColorsPalette.ROOM_COLORS.get(
-                key,
-                ColorsPalette.ROOM_COLORS.get(str(self._random.randint(1, 16)), (0, 0, 0)),
-            ),
-        )
+        if key in self._overriden_room_colors:
+            return self._overriden_room_colors[key]
+        if key in ColorsPalette.ROOM_COLORS:
+            return ColorsPalette.ROOM_COLORS[key]
+        return ColorsPalette.ROOM_COLORS.get(str(self._random.randint(1, 16)), (0, 0, 0))

--- a/src/vacuum_map_parser_base/config/color.py
+++ b/src/vacuum_map_parser_base/config/color.py
@@ -117,8 +117,8 @@ class ColorsPalette:
             self._overriden_room_colors = {}
         else:
             self._overriden_room_colors = room_colors
-        self._cached_colors = {}
-        self._cached_room_colors = {}
+        self._cached_colors: dict[SupportedColor, Color] = {}
+        self._cached_room_colors: dict[int, Color] = {}
 
     def get_color(self, color_name: SupportedColor) -> Color:
         if color_name not in self._cached_colors:


### PR DESCRIPTION
Idk why python does this - but it evaluates the default parameter for get() whenever it is called. So everytime - even though we have the data, it is still creating a random int.

This (while longer) change speeds up the code significantly.

For 2 maps getting parsed: 

Before:  get_room_color: .785 
After: .122 
Before:
get_color:
.455 after:
.160